### PR TITLE
added where support to iter; dramatically improved pipe applicability…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,23 @@
+0.13.0 (2021-05-16)
+-------------------
+
+Features
+++++++++
+
+- now ``c.iter`` supports ``where`` parameters just like ``c.generator_comp``:
+
+  * ``c.iter(c.this() + 1, where=c.this() > 0)``
+
+- now it's possible to use ``.pipe`` wherever you want as long as it lets you
+  do so, even piping in and out of reducers (``c.ReduceFuncs``)
+
+  * e.g. it will raise an Exception if you try to add labels to a reducer input
+
+- now it's possible to use ``aggregate`` inside ``aggregate`` as long as you
+  don't nest reducers
+
+----
+
 0.12.1 (2021-05-13)
 -------------------
 

--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -182,9 +182,8 @@ __________________________________________________
    - .. code-block:: python
 
       converter = c.list_comp(
-          c.this()
-      ).filter(
-          c.this() >= 5
+          c.this(),
+          where=c.this() >= 5
       ).pipe(
           c.if_(
               if_true=c.this(),
@@ -633,12 +632,11 @@ ___________________________________________
           (
               c.item("app_name").call_method("upper"),
               c.ReduceFuncs.DictSum(
-                  (
-                      # key
-                      (c.item("currency"), c.item("dt")),
-                      # value to be summed
-                      c.item("amount"),
-                  )
+                  # key
+                  (c.item("currency"), c.item("dt")),
+                  # value to be summed
+                  c.item("amount"),
+                  default=dict,
               ).call_method(
                   "items"
               ).iter(
@@ -648,7 +646,8 @@ ___________________________________________
                       c.input_arg("currency_to"),
                       c.item(0, 1),
                       c.item(1),
-                  )
+                  ),
+                  where=c.item(1)
               ).pipe(
                   c.call_func(sum, c.this())
               )

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -330,7 +330,9 @@ Next:
     * ``c.tuple_comp``, see :ref:`comprehensions section<ref_comprehensions>` for details:
 
   2. every comprehension supports if clauses to filter input:
-     ``c.list_comp(..., where=condition_conv)``
+     
+    * ``c.list_comp(..., where=condition_conv)``
+    * ``c.this().iter(..., where=condition_conv)``
 
   3. to avoid unnecessary function call overhead, there is a way to pass an inline
      python expression :ref:`c.inline_expr<ref_c_inline_expr>`
@@ -359,17 +361,18 @@ Next:
    ).gen_converter(debug=True)
 
    # compiled converter:
-
-   def converter268_422(data_):
+   def converter_n3(data_):
+       global labels_
        return sorted(
-           [
-               ((i268_194["value"]).bit_length())
-               for i268_194 in data_
-               if (i268_194["country"] == "US")
-           ],
-           key=vlambda273_26,
+           (
+               ((i_5k["value"]).bit_length())
+               for i_5k in data_
+               if (i_5k["country"] == "US")
+           ),
+           key=lambda_vq,
            reverse=True,
        )
+
 
 **Example of custom nested comprehension:**
 
@@ -453,8 +456,9 @@ A simple pipe first:
    ).gen_converter(debug=True)
 
    # GENERATES:
-   def converter35_941(data_):
-       return sum(((i32_722 * 2) for i32_722 in data_))
+   def converter_lv(data_):
+       global labels_
+       return sum(((i_s5 * 2) for i_s5 in data_))
 
 ____
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = convtools
-version = 0.12.1
+version = 0.13.0
 description = convtools is a python library to declaratively define conversions for processing collections, doing complex aggregations and joins.
 author = iTechArt Group
 author_email = mikita.almakou@itechart-group.com

--- a/src/convtools/__init__.py
+++ b/src/convtools/__init__.py
@@ -3,4 +3,4 @@ This object exposes the public API of conversions."""
 from .conversion import conversion  # noqa: F401
 
 
-__version__ = "0.12.1"
+__version__ = "0.13.0"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,11 +1,18 @@
 from types import GeneratorType
 
-from convtools.base import CodeGenerationOptionsCtx, _ConverterCallable
+from convtools.base import (
+    CodeGenerationOptionsCtx,
+    _ConverterCallable,
+    clean_line_cache,
+)
+from convtools.utils import RUCache
 
 from .utils import total_size
 
 
 class MemoryProfilingConverterCallable(_ConverterCallable):
+    linecache_keys = RUCache(10, clean_line_cache)
+
     def __call__(self, *args, **kwargs):
         size_before = total_size(self.__dict__)
         result = super().__call__(*args, **kwargs)

--- a/tests/test_comprehensions.py
+++ b/tests/test_comprehensions.py
@@ -92,45 +92,69 @@ def test_comprehension_filter_cast_assumptions():
 def test_comprehension_filter_concats():
     assert c.generator_comp(c.this()).filter(c.this() > 5).filter(
         c.this() < 10
-    ).as_type(list).execute(range(20), debug=True) == [6, 7, 8, 9]
+    ).as_type(list).execute(range(20), debug=False) == [6, 7, 8, 9]
     assert c.this().iter(c.this()).filter(c.this() > 5).filter(
         c.this() < 10
-    ).as_type(list).execute(range(20), debug=True) == [6, 7, 8, 9]
+    ).as_type(list).execute(range(20), debug=False) == [6, 7, 8, 9]
+
+
+def test_comprehension_where():
+    assert (
+        c.generator_comp(c.this().neg(), where=c.this() > 6)
+        .as_type(list)
+        .filter(c.this() > -9)
+        .execute(range(10), debug=False)
+    ) == [-7, -8]
+    assert (
+        c.this()
+        .iter(c.this().neg(), where=c.this() > 6)
+        .as_type(list)
+        .filter(c.this() > -9)
+        .execute(range(10), debug=False)
+    ) == [-7, -8]
+    assert (
+        c.iter(c.this().neg(), where=c.this() > 6)
+        .as_type(list)
+        .filter(c.this() > -9)
+        .execute(range(10), debug=False)
+    ) == [-7, -8]
 
 
 def test_comprehensions_sorting():
     assert c.generator_comp(c.this()).sort().execute(
-        [2, 1, 3], debug=True
+        [2, 1, 3], debug=False
     ) == [1, 2, 3]
-    assert c.list_comp(c.this()).sort().execute([2, 1, 3], debug=True) == [
+    assert c.list_comp(c.this()).sort().execute([2, 1, 3], debug=False) == [
         1,
         2,
         3,
     ]
     assert c.this().pipe(c.list_comp(c.this())).sort().execute(
-        [2, 1, 3], debug=True
+        [2, 1, 3], debug=False
     ) == [
         1,
         2,
         3,
     ]
     assert c.list_comp(c.this()).sort().sort(reverse=True).execute(
-        [2, 1, 3], debug=True
+        [2, 1, 3], debug=False
     ) == [3, 2, 1]
 
-    assert c.set_comp(c.this()).sort().execute([2, 2, 1, 3], debug=True) == [
+    assert c.set_comp(c.this()).sort().execute([2, 2, 1, 3], debug=False) == [
         1,
         2,
         3,
     ]
-    assert c.tuple_comp(c.this()).sort().execute([2, 2, 1, 3], debug=True) == (
+    assert c.tuple_comp(c.this()).sort().execute(
+        [2, 2, 1, 3], debug=False
+    ) == (
         1,
         2,
         2,
         3,
     )
     assert c.dict_comp(c.this() * -1, c.this()).sort().execute(
-        [2, 2, 1, 3], debug=True
+        [2, 2, 1, 3], debug=False
     ) == OrderedDict(
         [
             (-3, 3),

--- a/tests/test_joins.py
+++ b/tests/test_joins.py
@@ -182,7 +182,7 @@ def test_hash_joins():
             ),
         )
         .as_type(list)
-        .gen_converter(debug=True)
+        .gen_converter(debug=False)
     )
     assert join2(
         [
@@ -247,7 +247,7 @@ def test_nested_loop_joins():
             ),
         )
         .as_type(list)
-        .gen_converter(debug=True)
+        .gen_converter(debug=False)
     )
     assert join1(
         [
@@ -282,7 +282,7 @@ def test_nested_loop_joins():
     join3 = (
         c.join(c.item(0), c.item(1), Eq(c.LEFT + c.RIGHT, 1))
         .as_type(list)
-        .gen_converter(debug=True)
+        .gen_converter(debug=False)
     )
     assert join3(([-1, 0, 1], [2, 1, 1])) == [(-1, 2), (0, 1), (0, 1)]
 
@@ -300,7 +300,7 @@ def test_left_join():
             how="left",
         )
         .as_type(list)
-        .gen_converter(debug=True)
+        .gen_converter(debug=False)
     )
     assert join1([(0, 1, 2, 3, 3), (3, 3, 4, 5)]) == [
         (0, None),
@@ -326,7 +326,7 @@ def test_right_join():
             how="right",
         )
         .as_type(list)
-        .gen_converter(debug=True)
+        .gen_converter(debug=False)
     )
     assert join1([(0, 1, 2, 3, 3), (3, 3, 4, 5)]) == [
         (3, 3),
@@ -347,7 +347,7 @@ def test_outer_join():
             how="full",
         )
         .as_type(list)
-        .gen_converter(debug=True)
+        .gen_converter(debug=False)
     )
     assert join1(([0, 1, 2, 5], [2, 3, 4, 5])) == [
         (0, None),
@@ -370,7 +370,7 @@ def test_outer_join():
             how="outer",
         )
         .as_type(list)
-        .gen_converter(debug=True)
+        .gen_converter(debug=False)
     )
     assert join2([(10, 7, 8, 0, 1, 2, 3, 3), (3, 3, 4, 5, 8)]) == [
         (10, None),
@@ -393,7 +393,7 @@ def test_cross_join():
     join1 = (
         c.join(c.item(0), c.item(1), True)
         .as_type(list)
-        .gen_converter(debug=True)
+        .gen_converter(debug=False)
     )
     assert join1(([1, 2, 3], [5, 6])) == [
         (1, 5),

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -18,7 +18,7 @@ def test_labels():
             )
         ),
         2,
-    ).gen_converter(debug=True)
+    ).gen_converter(debug=False)
     assert conv1(data_=1, x={"cde": 2}, y={"abc": 3}) == 15
 
     list(c.generator_comp(c.this().add_label("a")).execute([1, 2]))

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -61,7 +61,7 @@ def test_mutation_attr():
             c.Mut.del_attr("a"),
             c.Mut.set_attr("c", 3),
         )
-    ).execute(obj, debug=True)
+    ).execute(obj, debug=False)
     assert not hasattr(obj, "a") and obj.b == 2 and obj.c == 3
 
     obj = A()
@@ -73,7 +73,7 @@ def test_mutation_attr():
             c.Mut.del_attr("a"),
             c.Mut.set_attr("c", 3),
         )
-    ).execute(obj, debug=True)
+    ).execute(obj, debug=False)
     assert not hasattr(obj, "a") and obj.b == 2 and obj.c == 3
 
 
@@ -93,7 +93,7 @@ def test_iter_mut_method():
             c.Mut.set_item("d", c.item("a") + 3),
         )
         .as_type(list)
-        .execute([1, 2, 3], debug=True)
+        .execute([1, 2, 3], debug=False)
     ) == [
         {"a": 1, "b": 2, "c": 3, "d": 4},
         {"a": 2, "b": 3, "c": 4, "d": 5},
@@ -118,7 +118,7 @@ def test_iter_mut_method():
             )
             .as_type(tuple)
         )
-        .execute([(0, 1), (0, 2), (1, 7)], base=100, debug=True)
+        .execute([(0, 1), (0, 2), (1, 7)], base=100, debug=False)
     )
     assert result == [
         ({0: 2, "x": 102}, {2: 0, "x": 100}),

--- a/tests/test_optional.py
+++ b/tests/test_optional.py
@@ -25,7 +25,7 @@ def test_optional_dict():
                 c.item("key1") * 500, skip_if=c.item("key1") < 5
             ): c.optional(c.item("key22"), skip_value=20),
         }
-    ).gen_converter(debug=True)
+    ).gen_converter(debug=False)
     assert conv([{"key1": 1, "key2": 2}, {"key1": 10, "key22": 20}], x=1) == [
         {"key1": 1, "key2": 2, "key3": 200, 2: 0},
         {"key1": 10, "key4": 3000, "key5": 3000, 4000: 20},
@@ -47,7 +47,7 @@ def test_optional_list_tuple_set():
             c.optional(c.item("key1") * 2, skip_value=20),
             c.optional(c.item("key1") * 3, skip_if=c.item("key1") < 5),
         ]
-    ).gen_converter(debug=True)
+    ).gen_converter(debug=False)
     assert conv([{"key1": 1, "key2": 2}, {"key1": 10, "key22": 20}]) == [
         [1, 2, 2],
         [10, 30],
@@ -59,7 +59,7 @@ def test_optional_list_tuple_set():
             c.optional(c.item("key1") * 2, skip_value=20),
             c.optional(c.item("key1") * 3, skip_if=c.item("key1") < 5),
         )
-    ).gen_converter(debug=True)
+    ).gen_converter(debug=False)
     assert conv([{"key1": 1, "key2": 2}, {"key1": 10, "key22": 20}]) == [
         (1, 2, 2),
         (10, 30),
@@ -71,7 +71,7 @@ def test_optional_list_tuple_set():
             c.optional(c.item("key1") * 2, skip_value=20),
             c.optional(c.item("key1") * 3, skip_if=c.item("key1") < 5),
         }
-    ).gen_converter(debug=True)
+    ).gen_converter(debug=False)
     assert conv([{"key1": 1, "key2": 2}, {"key1": 10, "key22": 20}]) == [
         {1, 2, 2},
         {10, 30},

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -132,3 +132,11 @@ def test_replace_word():
     for (where, word, with_what, expected_result) in cases:
         result = BaseConversion.replace_word(where, word, with_what)
         assert result == expected_result
+
+
+def test_count_words():
+    cases = [(" abc abc abc abc abcc aabc aabcc abc", "abc", 5)]
+
+    for (where, what, expected_result) in cases:
+        result = BaseConversion.count_words(where, what)
+        assert result == expected_result


### PR DESCRIPTION
- now ``c.iter`` supports ``where`` parameters just like ``c.generator_comp``:

  * ``c.iter(c.this() + 1, where=c.this() > 0)``

- now it's possible to use ``.pipe`` wherever you want as long as it lets you
  do so, even piping in and out of reducers (``c.ReduceFuncs``)

  * e.g. it will raise an Exception if you try to add labels to a reducer input

- now it's possible to use ``aggregate`` inside ``aggregate`` as long as you
  don't nest reducers
